### PR TITLE
Added: Path support in init and start command

### DIFF
--- a/.changeset/dry-peaches-bow.md
+++ b/.changeset/dry-peaches-bow.md
@@ -1,0 +1,5 @@
+---
+"overide": patch
+---
+
+Added support for `--path` option in `init` and `start` commands. This allows user to initialise and start overide in any target path on a system.

--- a/src/commands/command.init.ts
+++ b/src/commands/command.init.ts
@@ -24,6 +24,7 @@ class Initialize extends OiCommand {
 
     initCommand
       .option('-i, --ignore <files...>', 'Specify files or directories to ignore')
+      .option('-p, --path <path>', 'Specify the path to the project directory')
       .option('-n, --project-name <name>', 'Specify a project name')
       .action((options: InitOption) => {
         this.initializeProject(options);
@@ -54,54 +55,6 @@ class Initialize extends OiCommand {
   }
 
   /**
-   * Adds specified files to the ignore list in the configuration file (`oi-config.json`).
-   *
-   * @param {string|string[]} files - A file or an array of files to add to the ignore list.
-   */
-  addIgnoreFiles(files: string[]): void {
-    const configPath = CommandHelper.getConfigFilePath(false);
-
-    // Check if oi-config.json exists
-    if (!CommandHelper.configExists(false)) {
-      console.error(`Error: oi-config.json not found at ${configPath}`);
-      process.exit(1);
-    }
-
-    try {
-      // Read the current configuration file
-      const config: LocalConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-
-      // Ensure 'ignore' field exists in the configuration
-      if (!Array.isArray(config.ignore)) {
-        config.ignore = [];
-      }
-
-      // Convert a single file string into an array
-      if (typeof files === 'string') {
-        files = [files];
-      }
-
-      // Add each file to the ignore list if it is not already present
-      files.forEach(file => {
-        if (!config.ignore.includes(file)) {
-          config.ignore.push(file);
-          console.log(`Added ${file} to ignore list.`);
-        } else {
-          console.log(`${file} is already in the ignore list.`);
-        }
-      });
-
-      // Write the updated configuration back to oi-config.json
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log('Updated oi-config.json with new ignore files.');
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(`Error updating oi-config.json: ${error.message}`);
-      }
-    }
-  }
-
-  /**
    * Initializes the project by creating the configuration file (`oi-config.json`)
    * and setting up ignore files, project name, and other options. If the project
    * is already initialized, it will stop the process.
@@ -111,13 +64,18 @@ class Initialize extends OiCommand {
   async initializeProject(options: InitOption): Promise<void> {
     try {
       // Determine the output path for the configuration file
-      const outputPath = path.join(process.cwd(), 'oi-config.json');
-      const dependencyFilePath = path.join(process.cwd(), 'oi-dependency.json');
+      // Check if the path is passed in the options.
+      let outputPath = '';
+      if (options.path) {
+        outputPath = path.join(options.path, 'oi-config.json');
+      } else {
+        outputPath = path.join(process.cwd(), 'oi-config.json');
+      }
+
+      const dependencyFilePath = path.join(options.path ?? process.cwd(), 'oi-dependency.json');
       const ignoreFiles = options.ignore || [];
       const verbose = options.verbose || false;
       const projectName = options.projectName || 'default-project';
-
-      console.log(options);
 
       // Verbose mode: Display the initialization options
       if (verbose) {

--- a/src/commands/command.start.ts
+++ b/src/commands/command.start.ts
@@ -32,13 +32,17 @@ class Start extends OiCommand {
   configureCommand(): void {
     const startCommand = this.program
       .command('start')
+      .option('-p, --path <path>', 'Specify the path to the project directory')
       .description('Start watching files for prompt changes');
     this.addCommonOptions(startCommand); // Add common options such as --verbose
 
-    // Load the dependency graph from the oi-dependency.json file
-    this.dependencyGraph = configCommandUtil.loadDependencyGraph() as DependencyGraph[] | null;
-
-    startCommand.action((options: StartOption) => this.startWatch(options));
+    startCommand.action((options: StartOption) => {
+      // Load the dependency graph from the oi-dependency.json file
+      this.dependencyGraph = configCommandUtil.loadDependencyGraph(options.path) as
+        | DependencyGraph[]
+        | null;
+      this.startWatch(options);
+    });
   }
 
   /**
@@ -51,7 +55,7 @@ class Start extends OiCommand {
     console.log('Watching files for prompts...');
 
     try {
-      const { verbose } = options;
+      const { verbose, path } = options;
 
       if (!configCommandUtil.configExists()) {
         console.error('Error: oi-config.json file not found in the current directory.');
@@ -59,9 +63,13 @@ class Start extends OiCommand {
       }
 
       // get current config.
-      const config = (await configCommandUtil.readConfigFileData()) as LocalConfig;
+      const config = (await configCommandUtil.readConfigFileData(false, path)) as LocalConfig;
       const ignoredFiles = config.ignore || [];
-      const currentDir = process.cwd();
+      const currentDir = options.path ?? process.cwd();
+
+      if (verbose) {
+        console.log(`Watching files in directory: ${currentDir}`);
+      }
 
       this.watcher = chokidar.watch(currentDir, {
         persistent: true,

--- a/src/models/model.options.ts
+++ b/src/models/model.options.ts
@@ -1,4 +1,5 @@
 export interface InitOption {
+  path?: string;
   ignore?: string[];
   verbose?: boolean;
   projectName?: string;
@@ -6,6 +7,7 @@ export interface InitOption {
 
 export interface StartOption {
   verbose?: boolean;
+  path?: string;
 }
 
 export interface ConfigOption {

--- a/src/utilis/util.command.config.ts
+++ b/src/utilis/util.command.config.ts
@@ -20,8 +20,8 @@ class ConfigCommandUtil {
   private static globalConfigFileName = 'oi-global-config.json';
   private static dependencyFileName = 'oi-dependency.json';
 
-  loadDependencyGraph(): DependencyGraph[] | null {
-    const dependencyFilePath = this.getDependencyFilePath();
+  loadDependencyGraph(localPath?: string): DependencyGraph[] | null {
+    const dependencyFilePath = this.getDependencyFilePath(localPath);
     if (fs.existsSync(dependencyFilePath)) {
       const dependencyData = fs.readFileSync(dependencyFilePath, 'utf-8');
       const dependencyGraph = JSON.parse(dependencyData);
@@ -33,8 +33,8 @@ class ConfigCommandUtil {
   /**
    * Get the file path for the dependency file.
    */
-  public getDependencyFilePath(): string {
-    return path.join(process.cwd(), ConfigCommandUtil.dependencyFileName);
+  public getDependencyFilePath(localPath?: string): string {
+    return path.join(localPath ?? process.cwd(), ConfigCommandUtil.dependencyFileName);
   }
 
   /**
@@ -52,8 +52,8 @@ class ConfigCommandUtil {
    * @param {boolean} global - True if checking the global config, false for local.
    * @returns {boolean} - True if the configuration file exists, false otherwise.
    */
-  public configExists(global: boolean = false): boolean {
-    const configPath = this.getConfigFilePath(global);
+  public configExists(global: boolean = false, localPath?: string): boolean {
+    const configPath = this.getConfigFilePath(global, localPath);
     return fs.existsSync(configPath);
   }
 
@@ -63,10 +63,16 @@ class ConfigCommandUtil {
    * @param {boolean} global - True if retrieving the global config file path.
    * @returns {string} - The full path to the configuration file.
    */
-  public getConfigFilePath(global: boolean = false): string {
+  public getConfigFilePath(global: boolean = false, localPath?: string): string {
     if (global) {
       return path.join(this.getGlobalConfigDirectory(), ConfigCommandUtil.globalConfigFileName);
     }
+
+    if (localPath) {
+      // Return the local config file path from the specified directory
+      return path.join(localPath, ConfigCommandUtil.configFileName);
+    }
+    // Return the local config file path
     return path.join(process.cwd(), ConfigCommandUtil.configFileName);
   }
 
@@ -110,8 +116,11 @@ class ConfigCommandUtil {
    * @param {boolean} global - True if reading global config, false for local.
    * @returns {LocalConfig | GlobalConfig | null} - The configuration object or null if not found.
    */
-  public readConfigFileData(global: boolean = false): LocalConfig | GlobalConfig | null {
-    const configPath = this.getConfigFilePath(global);
+  public readConfigFileData(
+    global: boolean = false,
+    localPath?: string
+  ): LocalConfig | GlobalConfig | null {
+    const configPath = this.getConfigFilePath(global, localPath);
 
     if (!this.configExists(global)) {
       console.error(`Configuration file not found at ${configPath}`);
@@ -136,8 +145,12 @@ class ConfigCommandUtil {
    * @param {boolean} global - True if writing to global config, false for local.
    * @param {LocalConfig | GlobalConfig} data - The configuration data to write.
    */
-  public writeConfigFileData(global: boolean = false, data: LocalConfig | GlobalConfig): void {
-    const configPath = this.getConfigFilePath(global);
+  public writeConfigFileData(
+    global: boolean = false,
+    data: LocalConfig | GlobalConfig,
+    localPath?: string
+  ): void {
+    const configPath = this.getConfigFilePath(global, localPath);
 
     // Ensure the directory exists
     this.makeRequiredDirectories();


### PR DESCRIPTION
Added support for `--path` option in `init` and `start` commands. This allows user to initialise and start overide in any target path on a system. 